### PR TITLE
fix type annotation for function forward

### DIFF
--- a/tutorials/tagger/config_allennlp.py
+++ b/tutorials/tagger/config_allennlp.py
@@ -65,7 +65,7 @@ class LstmTagger(Model):
 
     def forward(self,
                 sentence: Dict[str, torch.Tensor],
-                labels: torch.Tensor = None) -> torch.Tensor:
+                labels: torch.Tensor = None) -> Dict[str,torch.Tensor]:
         mask = get_text_field_mask(sentence)
         embeddings = self.word_embeddings(sentence)
         encoder_out = self.encoder(embeddings, mask)


### PR DESCRIPTION
For the function forward, the return type annotation should be Dict[str, torch.Tensor], instead of torch.Tensor.